### PR TITLE
Define raw_input() for Python 3

### DIFF
--- a/cansina.py
+++ b/cansina.py
@@ -27,9 +27,9 @@ import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 try:
-    xrange          # Python 2
+    raw_input          # Python 2
 except NameError:
-    xrange = range  # Python 3
+    raw_input = input  # Python 3
 
 #   Default options
 #


### PR DESCRIPTION
This fixes a mistake that I made on my last PR where I defined xrange() instead of raw_input().  :-(