### PR TITLE
Better scripting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ optional arguments:
   --capitalize          Transform 'word' into 'Word'.
   --strip-extension     Strip word extension: word.ext into word
   --alpha               Filter non alphanumeric words from wordlist
+  --no-progress         Don't show tested words and progress. (For dumb terminals)
+  --no-colors           Don't use output colors to keep output clean, e.g. when redirecting output to file
 
 License, requests, etc: https://github.com/deibit/cansina
 ```
@@ -84,7 +86,7 @@ Screenshot
 Installing dependencies
 =======================
 
-pip install --user requests[security] or pip install -r requeriments.txt
+pip install --user requests[security] or pip install -r requirements.txt
 
 (try removing --user and install with sudo in case of errors)
 

--- a/cansina.py
+++ b/cansina.py
@@ -184,6 +184,8 @@ parser.add_argument('--strip-extension', dest='strip_extension',
         help="Strip word extension: word.ext into word", default=False, action="store_true")
 parser.add_argument('--alpha', dest='only_alpha',
         help="Filter non alphanumeric words from wordlist", default=False, action="store_true")
+parser.add_argument('--no-progress', dest='no_progress',
+        help="Don't show tested words and progress. (For dumb terminals)", default=False, action="store_true")
 
 args = parser.parse_args()
 
@@ -396,6 +398,7 @@ Console.start_eta_queue(30)
 Console.show_full_path = full_path
 Console.show_content_type = show_content_type
 Console.header()
+Console.set_show_progress(False if args.no_progress else True)
 
 #
 # Create the thread_pool and start the daemonized threads

--- a/cansina.py
+++ b/cansina.py
@@ -352,7 +352,9 @@ print("{:30} {:>}".format("Total requests:",  "%s (aprox: %s / thread)" %
 #
 # Manager queue configuration
 #
-database_name = urlparse.urlparse(target).hostname
+database_name = urlparse.urlparse(target).scheme + '_' + urlparse.urlparse(target).hostname
+if urlparse.urlparse(target).port is not None:
+    database_name += '_' + str(urlparse.urlparse(target).port)
 manager = DBManager(database_name)
 manager_lock = threading.Lock()
 

--- a/cansina.py
+++ b/cansina.py
@@ -186,6 +186,8 @@ parser.add_argument('--alpha', dest='only_alpha',
         help="Filter non alphanumeric words from wordlist", default=False, action="store_true")
 parser.add_argument('--no-progress', dest='no_progress',
         help="Don't show tested words and progress. (For dumb terminals)", default=False, action="store_true")
+parser.add_argument('--no-colors', dest='no_colors',
+        help="Disable coloring. (For dumb terminals)", default=False, action="store_true")
 
 args = parser.parse_args()
 
@@ -401,6 +403,7 @@ Console.show_full_path = full_path
 Console.show_content_type = show_content_type
 Console.header()
 Console.set_show_progress(False if args.no_progress else True)
+Console.set_show_colors(False if args.no_colors else True)
 
 #
 # Create the thread_pool and start the daemonized threads

--- a/cansina.py
+++ b/cansina.py
@@ -187,7 +187,7 @@ parser.add_argument('--alpha', dest='only_alpha',
 parser.add_argument('--no-progress', dest='no_progress',
         help="Don't show tested words and progress. (For dumb terminals)", default=False, action="store_true")
 parser.add_argument('--no-colors', dest='no_colors',
-        help="Disable coloring. (For dumb terminals)", default=False, action="store_true")
+        help="Don't use output colors to keep output clean, e.g. when redirecting output to file", default=False, action="store_true")
 
 args = parser.parse_args()
 

--- a/core/printer.py
+++ b/core/printer.py
@@ -88,10 +88,14 @@ class Console:
     number_of_requests = 0
     number_of_threads = 0
     show_progress = True
+    show_colors = True
     
     @staticmethod
     def set_show_progress(show_progress):
         Console.show_progress = show_progress
+
+    def set_show_colors(show_colors):
+        Console.show_colors = show_colors
 
     @staticmethod
     def start_eta_queue(size):
@@ -122,22 +126,26 @@ class Console:
         elif os.name == 'nt':
             return
 
-        color = ""
-        if task.response_code == "200":
-            color = GREEN
-        if task.response_code == "401" or task.response_code == "403":
-            color = RED
-        if task.response_code == "404" and (not task.response_code in task.banned_response_codes):
-            color = GRAY
-        if task.response_code == "301" or task.response_code == "302":
-            color = LBLUE
-        if task.response_code.startswith('5') or task.response_code == '400':
-            color = YELLOW
-        if task.content_detected:
-            color = MAGENTA
+        to_format = "{1: ^3} | {2: >10} | {3: >6} | {4: >4} | {7} [{0: >2}%] - {5: ^9} - {6}"
+        to_format_without_progress = "{0: ^3} | {1: >10} | {2: >6} | {3: >4} | {5:^} {4}"
 
-        to_format = color + "{1: ^3} | {2: >10} | {3: >6} | {4: >4} | {7} [{0: >2}%] - {5: ^9} - {6}" + ENDC
-        to_format_without_progress = color + "{0: ^3} | {1: >10} | {2: >6} | {3: >4} | {5:^} {4}" + ENDC
+        color = ""
+        if Console.show_colors:
+            if task.response_code == "200":
+                color = GREEN
+            if task.response_code == "401" or task.response_code == "403":
+                color = RED
+            if task.response_code == "404" and (not task.response_code in task.banned_response_codes):
+                color = GRAY
+            if task.response_code == "301" or task.response_code == "302":
+                color = LBLUE
+            if task.response_code.startswith('5') or task.response_code == '400':
+                color = YELLOW
+            if task.content_detected:
+                color = MAGENTA
+
+            to_format = color + to_format + ENDC
+            to_format_without_progress = color + to_format_without_progress + ENDC
 
         # User wants to see full path
         if Console.show_full_path:
@@ -176,7 +184,7 @@ class Console:
             t_encode = t_encode[:abs(COLUMNS - Console.MIN_COLUMN_SIZE)]
 
         # if an entry is about to be log, remove percentage and eta time
-        if color and not task.response_code in task.banned_response_codes:
+        if color is not None and not task.response_code in task.banned_response_codes:
             to_console = to_format_without_progress.format(task.response_code,
                                                     task.response_size,
                                                     task.number,
@@ -193,9 +201,9 @@ class Console:
                                           t_encode, content_type)
 
             sys.stdout.write(to_console[:COLUMNS-2])
+            sys.stdout.write('\r')
 
         sys.stdout.flush()
-        sys.stdout.write('\r')
 
-        if not os.name == 'nt':
+        if not os.name == 'nt' and Console.show_progress:
             sys.stdout.write("\x1b[0K")

--- a/core/printer.py
+++ b/core/printer.py
@@ -87,6 +87,11 @@ class Console:
     visited = {}
     number_of_requests = 0
     number_of_threads = 0
+    show_progress = True
+    
+    @staticmethod
+    def set_show_progress(show_progress):
+        Console.show_progress = show_progress
 
     @staticmethod
     def start_eta_queue(size):
@@ -180,14 +185,15 @@ class Console:
 
             sys.stdout.write(to_console[:COLUMNS-2] + os.linesep)
         # print with progress
-        else:
+        elif Console.show_progress:
             to_console = to_format.format(percentage, task.response_code,
                                           task.response_size, task.number,
                                           int(task.response_time),
                                           Console.eta,
                                           t_encode, content_type)
 
-        sys.stdout.write(to_console[:COLUMNS-2])
+            sys.stdout.write(to_console[:COLUMNS-2])
+
         sys.stdout.flush()
         sys.stdout.write('\r')
 


### PR DESCRIPTION
Added the options --no-colors and --no-progress so Cansina can be more easily used from scripting tasks.

Also made the db name more unique to avoid troubles when using multiple instances of Cansina on the same target with for example different ports.