### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python cansina.py -h"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Cansina
 ---
 
 [![Build Status](https://travis-ci.org/deibit/cansina.svg?branch=master)](https://travis-ci.org/deibit/cansina)
+[![Run on Repl.it](https://repl.it/badge/github/deibit/cansina)](https://repl.it/github/deibit/cansina)
 
 Cansina is a Web Content Discovery Application.
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/cansina).